### PR TITLE
Update am_map.c

### DIFF
--- a/am_map.c
+++ b/am_map.c
@@ -783,7 +783,7 @@ void AM_doFollowPlayer(void)
 //
 void AM_updateLightLev(void)
 {
-    static nexttic = 0;
+    static int nexttic = 0;
     //static int litelevels[] = { 0, 3, 5, 6, 6, 7, 7, 7 };
     static int litelevels[] = { 0, 4, 7, 10, 12, 14, 15, 15 };
     static int litelevelscnt = 0;


### PR DESCRIPTION
fixed a compiler warning: type defaults to `int' in declaration of `nexttic'.