### PR TITLE
Update m_fixed.h

### DIFF
--- a/m_fixed.h
+++ b/m_fixed.h
@@ -28,6 +28,10 @@
 #pragma interface
 #endif
 
+#ifndef alloca
+// Compiler does not seem to come with alloca defined.
+#define alloca __builtin_alloca
+#endif
 
 //
 // Fixed point, 32bit as 16.16.


### PR DESCRIPTION
Compiler does not seem to come with alloca defined.
Shut up following compiler warning: 

r_data.c: In function `R_GenerateLookup':
r_data.c:326: warning: implicit declaration of function `alloca'