### PR TITLE
Update d_main.c

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -1632,9 +1632,9 @@ void D_DoomMain (void)
     scr_printf ("V_Init: allocate screens.\n");
     V_Init ();
 
-	#ifdef _EE
-		SDL_SYS_TimerInit();
-	#endif
+	//#ifdef _EE
+	//	SDL_SYS_TimerInit();
+	//#endif
 
 
     scr_printf ("M_LoadDefaults: Load system defaults.\n");

--- a/d_main.c
+++ b/d_main.c
@@ -34,6 +34,8 @@ static const char rcsid[] = "$Id: d_main.c,v 1.8 1997/02/03 22:45:09 b1 Exp $";
 #include <stdio.h>
 #include <stdlib.h>
 #include <debug.h>
+#include <loadfile.h>
+#include <kernel.h>
 
 /// cosmito
 static char padBuf[256] __attribute__((aligned(64)));


### PR DESCRIPTION
This fixes the following warnings:

d_main.c:45: syntax error before "u32"
d_main.c:46: syntax error before "u32"
d_main.c: In function `D_Display':
d_main.c:361: warning: implicit declaration of function `RotateThreadReadyQueue'
d_main.c: At top level:
d_main.c:902: syntax error before "u32"
d_main.c: In function `padUtils_ReadButtonWait':
d_main.c:905: `port' undeclared (first use in this function)
d_main.c:905: (Each undeclared identifier is reported only once
d_main.c:905: for each function it appears in.)
d_main.c:905: `slot' undeclared (first use in this function)
d_main.c:905: `old_pad' undeclared (first use in this function)
d_main.c:905: `new_pad' undeclared (first use in this function)
d_main.c: At top level:
d_main.c:915: syntax error before "u32"
d_main.c: In function `padUtils_ReadButton':
d_main.c:919: `u32' undeclared (first use in this function)
d_main.c:919: syntax error before "paddata"
d_main.c:921: `port' undeclared (first use in this function)
d_main.c:921: `slot' undeclared (first use in this function)
d_main.c:924: `paddata' undeclared (first use in this function)
d_main.c:926: `new_pad' undeclared (first use in this function)
d_main.c:926: `old_pad' undeclared (first use in this function)
d_main.c: In function `IdentifyVersionAndSelect':
d_main.c:1144: warning: implicit declaration of function `SifLoadModule'
d_main.c:1147: warning: implicit declaration of function `SleepThread'
d_main.c:1177: warning: implicit declaration of function `scr_setXY'
d_main.c:1197: warning: implicit declaration of function `scr_printf'
d_main.c:1200: `u32' undeclared (first use in this function)
d_main.c:1200: syntax error before "old_pad"
d_main.c:1210: `old_pad' undeclared (first use in this function)
d_main.c:1210: `new_pad' undeclared (first use in this function)