### PR TITLE
Update d_net.c

### DIFF
--- a/d_net.c
+++ b/d_net.c
@@ -33,6 +33,7 @@ static const char rcsid[] = "$Id: d_net.c,v 1.3 1997/02/03 22:01:47 b1 Exp $";
 #include "g_game.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include <kernel.h>
 
 #define	NCMD_EXIT		0x80000000
 #define	NCMD_RETRANSMIT		0x40000000


### PR DESCRIPTION
Fix:
d_net.c:731: warning: implicit declaration of function `RotateThreadReadyQueue'