### PR TITLE
Update sjpcm_rpc.c

### DIFF
--- a/sjpcm_rpc.c
+++ b/sjpcm_rpc.c
@@ -165,3 +165,4 @@ void SjPCM_Quit()
 	SifCallRpc(&cd0,SJPCM_QUIT,0,(void*)(&sbuff[0]),0,(void*)(&sbuff[0]),0,0,0);
 	sjpcm_inited = 0;
 }
+


### PR DESCRIPTION
sjpcm_rpc.c:167:2: warning: no newline at end of file