### PR TITLE
Update d_main.c

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -1005,9 +1005,9 @@ void D_DoomMain (void)
     printf ("V_Init: allocate screens.\n");
     V_Init ();
 
-	#ifdef _EE
-		SDL_SYS_TimerInit();
-	#endif
+	//#ifdef _EE
+	//	SDL_SYS_TimerInit();
+	//#endif
 
 
     printf ("M_LoadDefaults: Load system defaults.\n");


### PR DESCRIPTION
d_main.c:1009: warning: implicit declaration of function `SDL_SYS_TimerInit'