### PR TITLE
Update p_inter.c

### DIFF
--- a/src/p_inter.c
+++ b/src/p_inter.c
@@ -474,13 +474,15 @@ P_TouchSpecialThing
 	break;
 	
       case SPR_MEDI:
-	if (!P_GiveBody (player, 25))
+	if (player->health >= MAXHEALTH)
 	    return;
 
 	if (player->health < 25)
 	    player->message = GOTMEDINEED;
 	else
 	    player->message = GOTMEDIKIT;
+	
+	P_GiveBody (player, 25);
 	break;
 
 	


### PR DESCRIPTION
Fix to display the message "Picked up a medikit that you REALLY need!". If the player's health is less than 25%, the "Picked up a medikit that you REALLY need!" message should be displayed.