### PR TITLE
Update ps2doom.c

### DIFF
--- a/src/ps2doom.c
+++ b/src/ps2doom.c
@@ -1,7 +1,7 @@
 #include <tamtypes.h>
 //#include <floatlib.h>
 #include <stdio.h>
-
+#include <string.h>
 #include "d_main.h"
 
 int gethostname(char *name, int len)


### PR DESCRIPTION
fix compiler warning:
src/ps2doom.c: In function `psp_do_cheat':
src/ps2doom.c:74: warning: implicit declaration of function `strlen'