### PR TITLE
Update i_video.c

### DIFF
--- a/src/i_video.c
+++ b/src/i_video.c
@@ -38,6 +38,7 @@ rcsid[] = "$Id: i_x.c,v 1.6 1997/02/03 22:45:10 b1 Exp $";
 #include "d_main.h"
 
 #include "doomdef.h"
+#include "w_wad.h"
 
 
 SDL_Surface *screen;


### PR DESCRIPTION
fix compiler warning:
src/i_video.c: In function `LoadDiskImage':
src/i_video.c:117: warning: implicit declaration of function `W_CacheLumpName'