### PR TITLE
Update d_main.c

### DIFF
--- a/src/d_main.c
+++ b/src/d_main.c
@@ -38,7 +38,7 @@ static const char rcsid[] = "$Id: d_main.c,v 1.8 1997/02/03 22:45:09 b1 Exp $";
 //extern int access(char *file, int mode);
 
 #define R_OK	4
-static int access(char *file, int mode)
+/*static int access(char *file, int mode)
 {
 	FILE *test_fp;
 
@@ -48,7 +48,7 @@ static int access(char *file, int mode)
 		return(0);
 	}
 	return(-1);
-}
+}*/
 
 #include "config.h"
 #include "doomdef.h"


### PR DESCRIPTION
Warning fix:
"src/d_main.c:42: warning: `access' defined but not used"