### PR TITLE
Update r_things.c

### DIFF
--- a/src/r_things.c
+++ b/src/r_things.c
@@ -789,7 +789,7 @@ void R_SortVisSprites (void)
     int			i;
     int			count;
     vissprite_t*	ds;
-    vissprite_t*	best;
+    vissprite_t*	best=0;
     vissprite_t		unsorted;
     fixed_t		bestscale;
 


### PR DESCRIPTION
Fix compiler warning:
"src/r_things.c: In function `R_SortVisSprites':
src/r_things.c:792: warning: `best' might be used uninitialized in this function"