### PR TITLE
Update s_sound.c

### DIFF
--- a/src/s_sound.c
+++ b/src/s_sound.c
@@ -651,7 +651,7 @@ S_ChangeMusic
 ( int			musicnum,
   int			looping )
 {
-    musicinfo_t*	music;
+    musicinfo_t*	music=0;
     char		namebuf[9];
 
     if ( (musicnum <= mus_None)


### PR DESCRIPTION
Fix compiler warning:
"src/s_sound.c: In function `S_ChangeMusic':
src/s_sound.c:654: warning: `music' might be used uninitialized in this function"