### PR TITLE
Update p_maputl.c

### DIFF
--- a/src/p_maputl.c
+++ b/src/p_maputl.c
@@ -111,8 +111,8 @@ P_BoxOnLineSide
 ( fixed_t*	tmbox,
   line_t*	ld )
 {
-    int		p1;
-    int		p2;
+    int		p1=0;
+    int		p2=0;
 	
     switch (ld->slopetype)
     {


### PR DESCRIPTION
Fix compiler warning:
"src/p_maputl.c: In function `P_BoxOnLineSide':
src/p_maputl.c:114: warning: `p1' might be used uninitialized in this function
src/p_maputl.c:115: warning: `p2' might be used uninitialized in this function"