### PR TITLE
Update ps2doom.c

### DIFF
--- a/src/ps2doom.c
+++ b/src/ps2doom.c
@@ -1,5 +1,4 @@
 #include <tamtypes.h>
-//#include <floatlib.h>
 #include <stdio.h>
 #include <string.h>
 #include "d_main.h"
@@ -14,10 +13,10 @@ u32 inet_addr(const char *cp)
 	return 0;
 }
 
-float pow(float a, float b)
+/*float pow(float a, float b)
 {
 	return powf(a,b);
-}
+}*/
 
 //**********************************************************************
 // ps2doom cheat support - code typing


### PR DESCRIPTION
Fix compiler warning:
"src/ps2doom.c: In function `pow':
src/ps2doom.c:19: warning: implicit declaration of function `powf'"