### PR TITLE
Update r_segs.c

### DIFF
--- a/src/r_segs.c
+++ b/src/r_segs.c
@@ -210,7 +210,7 @@ void R_RenderSegLoop (void)
     int			yl;
     int			yh;
     int			mid;
-    fixed_t		texturecolumn;
+    fixed_t		texturecolumn=0;
     int			top;
     int			bottom;
 


### PR DESCRIPTION
Fix compiler warning:
"src/r_segs.c: In function `R_RenderSegLoop':
src/r_segs.c:213: warning: `texturecolumn' might be used uninitialized in this function"