### PR TITLE
Update ps2doom.h

### DIFF
--- a/src/ps2doom.h
+++ b/src/ps2doom.h
@@ -2,13 +2,14 @@
 #define _PS2DOOM_H_
 
 #include <tcpip.h>
+#include <math.h>
 
 
 
 int gethostname(char *name, int len);
 u32 inet_addr(const char *cp);
 
-float pow(float a, float b);
+//float pow(float a, float b);
 
 #endif
 


### PR DESCRIPTION
Fix compiler warning:
"src/ps2doom.c: In function `pow':
src/ps2doom.c:19: warning: implicit declaration of function `powf'"