### PR TITLE
Update p_floor.c

### DIFF
--- a/src/p_floor.c
+++ b/src/p_floor.c
@@ -467,8 +467,8 @@ EV_BuildStairs
 
     floormove_t*	floor;
     
-    fixed_t		stairsize;
-    fixed_t		speed;
+    fixed_t		stairsize=0;
+    fixed_t		speed=0;
 
     secnum = -1;
     rtn = 0;


### PR DESCRIPTION
Fix compiler warning:
"src/p_floor.c: In function `EV_BuildStairs':
src/p_floor.c:470: warning: `stairsize' might be used uninitialized in this function
src/p_floor.c:471: warning: `speed' might be used uninitialized in this function"