### PR TITLE
Update m_misc.c

### DIFF
--- a/src/m_misc.c
+++ b/src/m_misc.c
@@ -317,7 +317,7 @@ void M_LoadDefaults (void)
     FILE*	f;
     char	def[80];
     char	strparm[100];
-    char*	newstring;
+    char*	newstring=0;
     int		parm;
     boolean	isstring;
     


### PR DESCRIPTION
Fix compiler warning:
"src/m_misc.c: In function `M_LoadDefaults':
src/m_misc.c:320: warning: `newstring' might be used uninitialized in this function"